### PR TITLE
Fix build output location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ Temporary Items
 dist
 .webpack
 .serverless/**/*.zip
+tsconfig.build.tsbuildinfo

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- build TypeScript output into `dist` root
- ignore `tsconfig.build.tsbuildinfo`

## Testing
- `npm test`
- `npm run start:prod`
- `docker-compose up --build` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843609286e88333a891018cf3190c17