### PR TITLE
Add request logger

### DIFF
--- a/src/common/middleware/logger.middleware.ts
+++ b/src/common/middleware/logger.middleware.ts
@@ -1,0 +1,10 @@
+import { RequestHandler } from 'express';
+
+export const requestLogger: RequestHandler = (req, res, next) => {
+  const start = Date.now();
+  res.on('finish', () => {
+    const ms = Date.now() - start;
+    console.log(`${req.method} ${req.originalUrl} ${res.statusCode} - ${ms}ms`);
+  });
+  next();
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import { policiesRouter } from './policies/policies.routes';
+import { requestLogger } from './common/middleware/logger.middleware';
 
 const app = express();
 app.use(express.json());
+app.use(requestLogger);
 
 app.get('/', (_req, res) => {
   res.send('Hello World!');


### PR DESCRIPTION
## Summary
- add simple request logging middleware
- register logger in app startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843642081088333878a7e0ca1187d3f